### PR TITLE
Add hg_root values to hg.m.o. trees

### DIFF
--- a/config.json
+++ b/config.json
@@ -7,6 +7,7 @@
       "files_path": "$WORKING/nss/git",
       "git_path": "$WORKING/nss/git",
       "git_blame_path": "$WORKING/nss/blame",
+      "hg_root": "https://hg.mozilla.org/projects/nss",
       "objdir_path": "$WORKING/nss/dist",
       "codesearch_path": "$WORKING/nss/livegrep.idx",
       "codesearch_port": 8081
@@ -17,6 +18,7 @@
       "files_path": "$WORKING/mozilla-central/gecko-dev",
       "git_path": "$WORKING/mozilla-central/gecko-dev",
       "git_blame_path": "$WORKING/mozilla-central/gecko-blame",
+      "hg_root": "https://hg.mozilla.org/mozilla-central",
       "objdir_path": "$WORKING/mozilla-central/objdir",
       "codesearch_path": "$WORKING/mozilla-central/livegrep.idx",
       "codesearch_port": 8082
@@ -25,6 +27,7 @@
     "comm-central": {
       "index_path": "$WORKING/comm-central",
       "files_path": "$WORKING/comm-central/comm-central",
+      "hg_root": "https://hg.mozilla.org/comm-central",
       "objdir_path": "$WORKING/comm-central/objdir",
       "codesearch_path": "$WORKING/comm-central/livegrep.idx",
       "codesearch_port": 8083


### PR DESCRIPTION
This will allow the mozsearch code to provide customized log/raw links
for files in these repos, rather than just pointing to URLs with
mozilla-central hard-coded in them.

Goes with https://github.com/bill-mccloskey/mozsearch/pull/31